### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,8 +18,15 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def
-  # end
+  # 通話が切れてしまったいますね。
+  # zoomで対応できますがいかがでしょうか？
+  # 了解です
+  # https://zoom.us/j/8865739237?pwd=WEJNNHZiRHphQytTdkgyNmZ4cGkvQT09 
+  # kotiranionegaiitasimasu 
+  # 入室してみます
+  def show
+    @item = Item.find(params[:id])
+  end
 
   # def
   # end
@@ -36,7 +43,6 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:image, :item_name, :category_id, :condition_id, :prefectures_id, :date_of_shipment_id, :price,
-                                 :shipping_charge_id, :explanation).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :item_name, :category_id, :condition_id, :prefecture_id, :date_of_shipment_id, :price,:shipping_charge_id, :explanation).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,12 +18,6 @@ class ItemsController < ApplicationController
     end
   end
 
-  # 通話が切れてしまったいますね。
-  # zoomで対応できますがいかがでしょうか？
-  # 了解です
-  # https://zoom.us/j/8865739237?pwd=WEJNNHZiRHphQytTdkgyNmZ4cGkvQT09 
-  # kotiranionegaiitasimasu 
-  # 入室してみます
   def show
     @item = Item.find(params[:id])
   end
@@ -43,6 +37,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:image, :item_name, :category_id, :condition_id, :prefecture_id, :date_of_shipment_id, :price,:shipping_charge_id, :explanation).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :item_name, :category_id, :condition_id, :prefecture_id, :date_of_shipment_id, :price,
+                                 :shipping_charge_id, :explanation).merge(user_id: current_user.id)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -13,5 +13,4 @@ class Category < ActiveHash::Base
   ]
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,4 @@
-class Genre < ActiveHash::Base
+class Category < ActiveHash::Base
   self.data = [
     { id: 0, name: '---' },
     { id: 1, name: 'レディース' },
@@ -11,4 +11,7 @@ class Genre < ActiveHash::Base
     { id: 8, name: 'ハンドメイド' },
     { id: 9, name: 'その他' }
   ]
+  include ActiveHash::Associations
+  has_many :items
+
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -10,5 +10,4 @@ class Condition < ActiveHash::Base
   ]
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -8,4 +8,7 @@ class Condition < ActiveHash::Base
     { id: 5, name: '傷や汚れあり' },
     { id: 6, name: '全体的に状態が悪い' }
   ]
+  include ActiveHash::Associations
+  has_many :items
+
 end

--- a/app/models/date_of_shipment.rb
+++ b/app/models/date_of_shipment.rb
@@ -5,4 +5,7 @@ class DateOfShipment < ActiveHash::Base
     { id: 2, name: '2~3日で発送' },
     { id: 3, name: '4~7日で発送' }
   ]
+  include ActiveHash::Associations
+  has_many :items
+
 end

--- a/app/models/date_of_shipment.rb
+++ b/app/models/date_of_shipment.rb
@@ -7,5 +7,4 @@ class DateOfShipment < ActiveHash::Base
   ]
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,14 +4,14 @@ class Item < ApplicationRecord
   with_options numericality: { other_than: 0 } do
     validates :category_id
     validates :condition_id
-    validates :prefectures_id
+    validates :prefecture_id
     validates :date_of_shipment_id
     validates :shipping_charge_id
   end
   with_options presence: true do
     validates :category_id
     validates :condition_id
-    validates :prefectures_id
+    validates :prefecture_id
     validates :date_of_shipment_id
     validates :shipping_charge_id
     validates :item_name
@@ -20,12 +20,14 @@ class Item < ApplicationRecord
   end
   validates :price, presence: true, inclusion: { in: 300..9_999_999 }
 
+  belongs_to :user
   has_one :history
   has_one_attached :image
-  belongs_to_active_hash :genre
-  belongs_to_active_hash :prefecture
-  belongs_to_active_hash :condition
-  belongs_to_active_hash :date_of_shipment
-  belongs_to_active_hash :shipping_charge
-  belongs_to :user
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :category
+  belongs_to :prefecture
+  belongs_to :condition
+  belongs_to :date_of_shipment
+  belongs_to :shipping_charge
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -19,5 +19,4 @@ class Prefecture < ActiveHash::Base
   ]
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -17,4 +17,7 @@ class Prefecture < ActiveHash::Base
     { id: 43, name: '熊本県' }, { id: 44, name: '大分県' }, { id: 45, name: '宮崎県' },
     { id: 46, name: '鹿児島県' }, { id: 47, name: '沖縄県' }
   ]
+  include ActiveHash::Associations
+  has_many :items
+
 end

--- a/app/models/shipping_charge.rb
+++ b/app/models/shipping_charge.rb
@@ -6,5 +6,4 @@ class ShippingCharge < ActiveHash::Base
   ]
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/shipping_charge.rb
+++ b/app/models/shipping_charge.rb
@@ -4,4 +4,7 @@ class ShippingCharge < ActiveHash::Base
     { id: 1, name: '着払い(購入者負担)' },
     { id: 2, name: '送料込み(出品者負担)' }
   ]
+  include ActiveHash::Associations
+  has_many :items
+
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
       <% @items.each do|item|%>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
             <%= image_tag(item.image, class: "item-img") %>
 
@@ -145,7 +145,7 @@
               <%= item.item_name %>
             </h3>
             <div class='item-price'>
-              <span><%= item.price %>円<br><%= "税込" %></span>
+              <span><%= item.price %>円<br><%= item.shipping_charge.name %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -48,7 +48,7 @@
             カテゴリー
             <span class="indispensable">必須</span>
           </div>
-          <%= f.collection_select(:category_id, Genre.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+          <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
           <div class="weight-bold-text">
             商品の状態
             <span class="indispensable">必須</span>
@@ -74,7 +74,7 @@
             発送元の地域
             <span class="indispensable">必須</span>
           </div>
-          <%= f.collection_select(:prefectures_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+          <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
           <div class="weight-bold-text">
             発送までの日数
             <span class="indispensable">必須</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,68 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <%# <div class="sold-out"> %>
+        <%# <span>Sold Out!!</span> %>
+      <%# </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_charge.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% unless user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.date_of_shipment.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,6 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
@@ -34,8 +33,6 @@
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <div class="item-explain-box">
       <span><%= @item.explanation %></span>
     </div>
@@ -102,9 +99,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -17,21 +17,23 @@
     <div class="item-price-box">
       <span class="item-price">
         <%= @item.price %>
+        円
       </span>
       <span class="item-postage">
         <%= @item.shipping_charge.name %>
       </span>
     </div>
 
-    <% if user_signed_in? && current_user.id == @item.user_id %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-      <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-    <% end %>
-    <%if user_signed_in? %> 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user_id %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <% else %>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
     <% end %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -100,7 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,8 @@
       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+    <% end %>
+    <%if user_signed_in? %> 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,13 +28,11 @@
       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-    <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <% unless user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>

--- a/db/migrate/20210130091546_create_items.rb
+++ b/db/migrate/20210130091546_create_items.rb
@@ -5,7 +5,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.string  :item_name,           null: false
       t.integer :category_id,         null: false
       t.integer :condition_id,        null: false
-      t.integer :prefectures_id,      null: false
+      t.integer :prefecture_id,       null: false
       t.integer :date_of_shipment_id, null: false
       t.integer :price,               null: false
       t.integer :shipping_charge_id,  null: false

--- a/db/migrate/20210214050327_rename_prefectures_id_column_to_items.rb
+++ b/db/migrate/20210214050327_rename_prefectures_id_column_to_items.rb
@@ -1,0 +1,5 @@
+class RenamePrefecturesIdColumnToItems < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :items, :prefectures_id, :prefecture_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_03_054733) do
+ActiveRecord::Schema.define(version: 2021_02_14_050327) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 2021_02_03_054733) do
     t.string "item_name", null: false
     t.integer "category_id", null: false
     t.integer "condition_id", null: false
-    t.integer "prefectures_id", null: false
+    t.integer "prefecture_id", null: false
     t.integer "date_of_shipment_id", null: false
     t.integer "price", null: false
     t.integer "shipping_charge_id", null: false

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     price                { 1000 }
     category_id          { 2 }
     condition_id         { 2 }
-    prefecture_id       { 2 }
+    prefecture_id { 2 }
     date_of_shipment_id  { 2 }
     shipping_charge_id   { 2 }
     association :user

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     price                { 1000 }
     category_id          { 2 }
     condition_id         { 2 }
-    prefectures_id       { 2 }
+    prefecture_id       { 2 }
     date_of_shipment_id  { 2 }
     shipping_charge_id   { 2 }
     association :user

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -48,13 +48,13 @@ RSpec.describe Item, type: :model do
       end
 
       it '発送元の地域についての情報が必須であること' do
-        @item.prefectures_id = nil
+        @item.prefecturs_id = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Prefectures can't be blank", 'Prefectures is not a number')
       end
 
       it '発送元の地域についての情報がのとき' do
-        @item.prefectures_id = 0
+        @item.prefecture_id = 0
         @item.valid?
         expect(@item.errors.full_messages).to include('Prefectures must be other than 0')
       end


### PR DESCRIPTION
## すみません。
途中でエラーが起きたので、いろんな箇所で修正・追加が行われています。

# What
商品詳細表示実装する

# Why
商品詳細を表示させる為

# ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
https://gyazo.com/0d51638481b4d988d6eadb1afca704e5

# ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
https://gyazo.com/5b876757958899022035e3406c813274

# ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
https://gyazo.com/b4baf43e5c0526ccda04f2cc3d03f31f

# ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
https://gyazo.com/a6158eb71b372119856b52f58fcfeadb

## なお商品購入機能はに導入です

## よろしくお願いします。

# 以下修正
## ご指摘にあった【ログアウトユーザーでも"購入ボタン"が表示されている】を修正
https://gyazo.com/3f808337319c134982137013348998c9

再度よろしくお願いします。 

# 以下再々修正
## ログイン状態の出品者のみ、「編集・削除ボタン」が表示される動画
 https://gyazo.com/a5dd9f3c8ddbabd04ea45272133020d0
よろしくお願いします。